### PR TITLE
Allow for unmasked data

### DIFF
--- a/dev/testing.py
+++ b/dev/testing.py
@@ -13,14 +13,16 @@ if __name__=='__main__':
     log_to_file(fname+'.klg.'+str(shank), 'debug')
     #log_suppress_hierarchy('klustakwik', inclusive=False)
 
-    if os.path.exists(fname+'.pickle'):
-#     if False:
+    # if os.path.exists(fname+'.pickle'):
+    if False:
         start_time = time.time()
         data = pickle.load(open(fname+'.pickle', 'rb'))
         print('load from pickle:', time.time()-start_time)
     else:
         start_time = time.time()
-        raw_data = load_fet_fmask_to_raw(fname, shank, drop_last_n_features=1)
+        raw_data = load_fet_fmask_to_raw(fname, shank, drop_last_n_features=1,
+                                         use_fmask=False,
+                                         )
         print('load_fet_fmask_to_raw:', time.time()-start_time)
         data = raw_data.to_sparse_data()
         pickle.dump(data, open(fname+'.pickle', 'wb'), -1)
@@ -41,7 +43,8 @@ if __name__=='__main__':
 #             fast_split=True,
 #             max_split_iterations=10,
             consider_cluster_deletion=True,
-            #num_cpus=1,
+            num_cpus=1,
+            num_starting_clusters=50,
             )
 #     kk.register_callback(SaveCluEvery(fname, shank, every=1))
     kk.register_callback(MonitoringServer())
@@ -73,7 +76,7 @@ if __name__=='__main__':
     else:
         print('Generating clusters from scratch')
         #kk.cluster_with_subset_schedule(100, [0.99, 1.0])
-        kk.cluster_mask_starts()
+        kk.cluster_mask_or_random_starts()
 
 #     clusters = loadtxt('../temp/testsmallish.start.clu', skiprows=1, dtype=int)
 # #     dump_covariance_matrices(kk)

--- a/klustakwik2/clustering.py
+++ b/klustakwik2/clustering.py
@@ -247,6 +247,20 @@ class KK(object):
         clusters = mask_starts(self.data, self.num_starting_clusters, self.num_special_clusters)
         self.cluster_from(clusters)
 
+    def cluster_random_starts(self):
+        clusters = randint(self.num_special_clusters,
+                           self.num_special_clusters+self.num_starting_clusters,
+                           size=self.data.num_spikes)
+        self.cluster_from(clusters)
+
+    def cluster_mask_or_random_starts(self):
+        if self.data.num_masks<self.num_starting_clusters:
+            self.log('info', 'Using random starts')
+            self.cluster_random_starts()
+        else:
+            self.log('info', 'Using mask starts')
+            self.cluster_mask_starts()
+
     def cluster_from(self, clusters, recurse=True, score_target=-inf):
         self.log('info', 'Clustering data set of %d points, %d features' % (self.data.num_spikes,
                                                                             self.data.num_features))

--- a/klustakwik2/scripts/kk2_legacy.py
+++ b/klustakwik2/scripts/kk2_legacy.py
@@ -25,6 +25,7 @@ def main():
         use_noise_cluster=True,
         use_mua_cluster=True,
         subset_schedule=None,
+        use_fmask=True,
         )
     (fname, shank), params = parse_args(2, script_params, __doc__.strip()+'\n',
                                         string_args=set(['start_from_clu']))
@@ -39,6 +40,7 @@ def main():
     use_noise_cluster = params.pop('use_noise_cluster')
     use_mua_cluster = params.pop('use_mua_cluster')
     subset_schedule = params.pop('subset_schedule')
+    use_fmask = params.pop('use_fmask')
     
     if subset_schedule is not None:
         if save_clu_every is not None:
@@ -54,7 +56,8 @@ def main():
     log_suppress_hierarchy('klustakwik', inclusive=False)
 
     start_time = time.time()
-    raw_data = load_fet_fmask_to_raw(fname, shank, drop_last_n_features=drop_last_n_features)
+    raw_data = load_fet_fmask_to_raw(fname, shank, drop_last_n_features=drop_last_n_features,
+                                     use_fmask=use_fmask)
     log_message('debug', 'Loading data from .fet and .fmask file took %.2f s' % (time.time()-start_time))
     data = raw_data.to_sparse_data()
     
@@ -70,7 +73,7 @@ def main():
     
     if start_from_clu is None:
         if subset_schedule is None:
-            kk.cluster_mask_starts()
+            kk.cluster_mask_or_random_starts()
         else:
             kk.cluster_with_subset_schedule(num_starting_clusters, subset_schedule)
     else:


### PR DESCRIPTION
Added a new boolean option `use_fmask` to `load_fet_fmask_to_raw` that allows you to automatically have all 1's for the mask if you don't have a `.fmask` file. Also added a new `KK.cluster_mask_or_random_starts` entry point that will use mask starts if it is large enough, or random starts if there are insufficient masks. Added a new option to `kk2_legacy` script to not load the fmask, and modified to use the new entry point.
