### PR TITLE
removed log at import

### DIFF
--- a/klustakwik2/__init__.py
+++ b/klustakwik2/__init__.py
@@ -10,5 +10,3 @@ from .default_parameters import *
 
 __version__ = '0.2.5'
 __version__ = get_kk_version(__version__)
-
-log_message('info', 'KlustaKwik2 version '+__version__)


### PR DESCRIPTION
Hi @rossant 

We developed a framework called SpikeInterface that implements several sorters (https://github.com/SpikeInterface).

At import, it tries to import the spike sorter-related packages to check if they are installed.
Klusta has a log ouput in the __init__, so I was wondering if you are ok in removing it from the init.

Thanks,
Alessio 